### PR TITLE
Use tabs instead of spaces for indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install from Sublime's Package Control.
 
 This package has five snippets, use as follows:
 
-	describe<tab>
+	desc<tab>
 	befr<tab>
 	aftr<tab>
 	suite<tab>

--- a/after.sublime-snippet
+++ b/after.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 after${1:Each}(function (${2:done}) {
-  ${3:// test!}
+	${3:}
 });
 ]]></content>
 	<tabTrigger>aftr</tabTrigger>

--- a/before.sublime-snippet
+++ b/before.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 before${1:Each}(function (${2:done}) {
-  ${3:// test!}
+	${3:}
 });
 ]]></content>
 	<tabTrigger>befr</tabTrigger>

--- a/describe.sublime-snippet
+++ b/describe.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
 describe('${1:what?}', function () {
-  it('${2:should do what?}', function (${3:done}) {
-    ${4:// test!}
-  });
+	it('${2:should do what?}', function (${3:done}) {
+		${4:}
+	});
 });
 ]]></content>
 	<tabTrigger>desc</tabTrigger>

--- a/it.sublime-snippet
+++ b/it.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content><![CDATA[
 it('${1:should do what...}', function(){
-  ${0: // test!}
+	${0:}
 });
 ]]></content>
     <tabTrigger>it</tabTrigger>

--- a/suite.sublime-snippet
+++ b/suite.sublime-snippet
@@ -1,12 +1,12 @@
 <snippet>
 <content><![CDATA[suite( '${1:suiteName}', function() {
-  ${2:setup(function(){
-    ${3}
-  \});}
+	${2:setup(function(){
+		${3}
+	\});}
 
-  ${4:teardown(function(){
-    ${5}
-  \});}
+	${4:teardown(function(){
+		${5}
+	\});}
 
   ${6}
 });]]></content>

--- a/test.sublime-snippet
+++ b/test.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[test( '${1:test}', function(${2:done}) {
-  ${3}
+	${3}
 });]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
   <tabTrigger>test</tabTrigger>


### PR DESCRIPTION
I currently work on a project, where we have 4 spaces for indentation.

This means that these snippets are not indented right in that project.

Using tabs in the snippets, will convert to whatever preferences you have set in Sublime.

I.e., if you are using 2 spaces, and have Sublime automatically convert spaces to tabs, this change will make the snippets behave as if there were spaces in them.

Oh, and I fixed a typo in the readme.
