### PR TITLE
Do not have an it-block within the describe

### DIFF
--- a/describe.sublime-snippet
+++ b/describe.sublime-snippet
@@ -1,9 +1,7 @@
 <snippet>
 	<content><![CDATA[
 describe('${1:what?}', function () {
-	it('${2:should do what?}', function (${3:done}) {
-		${4:}
-	});
+	${0:}
 });
 ]]></content>
 	<tabTrigger>desc</tabTrigger>


### PR DESCRIPTION
Often, I have a beforeEach after the describe, so I will have to delete the generated it-block.

And, as it is really easy to add an it-block, just it<tab>, I propose not having it in there as a default.
