### PR TITLE
`it` as the placeholder in body of `describe`

### DIFF
--- a/describe.sublime-snippet
+++ b/describe.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 describe('${1:what?}', function () {
-	${0:}
+	${0:it}
 });
 ]]></content>
 	<tabTrigger>desc</tabTrigger>


### PR DESCRIPTION
Since you removed `it` from `describe`, lets bring it back in a more clever/optional way, by putting it as a placeholder of `$0` in `describe`.
If you want `it`, just press <kbd>tab</kbd> to trigger `it`.
